### PR TITLE
Added XDG Base Directory support

### DIFF
--- a/main.go
+++ b/main.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/jroimartin/gocui"
+    "github.com/zchee/go-xdgbasedir"
 )
 
 func NewHandler(ui *UI, g *gocui.Gui) http.Handler {
@@ -31,18 +32,23 @@ func NewHandler(ui *UI, g *gocui.Gui) http.Handler {
 }
 
 func defaultConfigPath() string {
-	var path = ".httplab"
+    var configFilename = "httplab"
+    var dotConfigFilename = "." + configFilename
 
-	if _, err := os.Stat(path); !os.IsNotExist(err) {
-		return path
+    if _, err := os.Stat(xdgbasedir.ConfigHome()); !os.IsNotExist(err) {
+        return xdgbasedir.ConfigHome() + "/" + configFilename
+    }
+
+	if _, err := os.Stat(dotConfigFilename); !os.IsNotExist(err) {
+		return dotConfigFilename
 	}
 
 	u, err := user.Current()
 	if err != nil {
-		return path
+		return dotConfigFilename
 	}
 
-	return u.HomeDir + "/" + path
+	return u.HomeDir + "/" + dotConfigFilename
 }
 
 func main() {


### PR DESCRIPTION
There is a recent go package that adds XDG Base Directory support to golang programs,
https://github.com/zchee/go-xdgbasedir
More about this at https://wiki.archlinux.org/index.php/XDG_Base_Directory_support

This pull request uses go-xgdbasedir in order to store the configuration file to the designated config dir of the system.
The filename for the configuration is *httplab*.

Tested on Ubuntu.
