### PR TITLE
Add snapcraft yaml to enable builds of snaps

### DIFF
--- a/contrib/snap/snapcraft.yaml
+++ b/contrib/snap/snapcraft.yaml
@@ -17,6 +17,6 @@ apps:
 parts:
   httplab:
     plugin: go
-    source: .
+    source: ../../
     source-type: git
     go-importpath: github.com/gchaincl/httplab

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,22 @@
+name: httplab
+version: '0.1.0+git'
+summary: An interactive web server
+description: |
+  HTTPLabs let you inspect HTTP requests and forge responses.
+
+grade: stable
+confinement: strict
+
+apps:
+  httplab:
+    command: httplab
+    plugs:
+      - network
+      - network-bind
+
+parts:
+  httplab:
+    plugin: go
+    source: .
+    source-type: git
+    go-importpath: github.com/gchaincl/httplab


### PR DESCRIPTION
Hello!

This PR adds support for building snaps of httplab via snapcraft - see http://snapcraft.io/ for more information. Hooking this up means that builds of master can be pushed to the store and make latest builds of httplab are immediately available to millions of users. 

To test the build used to make the snap, on an up to date 16.04 machine

apt install snapcraft

git clone http://github.com/popey/httplab
git checkout add-snapcraft
cd httplab
snapcraft

This will build a snap which can be installed via:-

snap install httplab_0.1.0+git_amd64.snap --dangerous

(the --dangerous is required as it's an unsigned package being side-loaded, rather than a signed one from the store).

Test the application as expected.

Would be great to get this merged, and then hook up the automated builds to land in the store directly, as per http://snapcraft.io/docs/build-snaps/ci-integration. Happy to help through that process. We also have an automated system at http://build.snapcraft.io/ which could be used to auto-build and push to the store.

Once published in the store, it can be installed with:-

snap install httplab --edge

Later, when pushed to the stable store, it can be installed with:-

snap insatll httplab
