### PR TITLE
Add instructions to install snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,12 @@ go install github.com/gchaincl/httplab/cmd/httplab
 yaourt httplab
 ```
 
+### Snap
+On [systems](https://snapcraft.io/docs/core/install) where snap is supported:
+```
+snap install httplab
+```
+
 ### Binary distribution
 Each release provides pre-built binaries for different architectures, you can download them here: https://github.com/gchaincl/httplab/releases/latest
 


### PR DESCRIPTION

This pull request adds installation instructions for users of [snap enabled Linux distributions](https://snapcraft.io/docs/core/install). Snaps enable ISVs and projects to make their software available to millions of Linux users via the snap store and directly control delivery of software updates to their users. Snaps of desktop applications will also be available via the desktop Software Center, improving the discover-ability of your software. Your software can be installed with a simple `snap install httplab` simplifying the installation instructions for your users.

I uploaded a snap of httplab to the snap store, so now it can easily be installed using the snap tool. I added instructions to the readme.md.