### PR TITLE
Includes go get to avoid install failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ HTTPLabs let you inspect HTTP requests and forge responses.
 # Install
 ### Golang
 ```bash
+go get github.com/gchaincl/httplab
 go install github.com/gchaincl/httplab/cmd/httplab
 ```
 


### PR DESCRIPTION
This PR will avoid the install errors if the package is not in our `$GOPATH`.

Ping @gchaincl 