### PR TITLE
Issue #47 - Display request headers in a sorted order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## v0.4.0-dev
+* Display request headers in a sorted way on the client (issue $47)
 * [bugfix] Location header not rendered to client (@vjeantet, issue #44)
 * CORS support via `-cors` (issue #39)
 

--- a/dump.go
+++ b/dump.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -63,7 +64,13 @@ func DumpRequest(req *http.Request) ([]byte, error) {
 		req.ProtoMinor,
 	)
 
-	for key := range req.Header {
+	var keys []string
+	for k := range req.Header {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, key := range keys {
 		val := req.Header.Get(key)
 		fmt.Fprintf(buf, "%s: %s\n", withColor(31, key), withColor(32, val))
 	}

--- a/dump.go
+++ b/dump.go
@@ -64,12 +64,7 @@ func DumpRequest(req *http.Request) ([]byte, error) {
 		req.ProtoMinor,
 	)
 
-	var keys []string
-	for k := range req.Header {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-
+	keys := sortedHeaderKeys(req)
 	for _, key := range keys {
 		val := req.Header.Get(key)
 		fmt.Fprintf(buf, "%s: %s\n", withColor(31, key), withColor(32, val))
@@ -77,4 +72,13 @@ func DumpRequest(req *http.Request) ([]byte, error) {
 
 	err := writeBody(buf, req)
 	return buf.Bytes(), err
+}
+
+func sortedHeaderKeys(req *http.Request) []string {
+	var keys []string
+	for k := range req.Header {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }

--- a/dump_test.go
+++ b/dump_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"strings"
-	//"sort"
 	"sort"
 )
 

--- a/dump_test.go
+++ b/dump_test.go
@@ -8,6 +8,9 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"strings"
+	//"sort"
+	"sort"
 )
 
 func TestDumpRequestWithJSON(t *testing.T) {
@@ -31,6 +34,26 @@ func TestDumpRequestWithJSON(t *testing.T) {
 		buf, err := DumpRequest(req)
 		require.NoError(t, err)
 		fmt.Printf("%s\n", buf)
+	})
+}
+
+func TestDumpRequestHeaders(t *testing.T) {
+	t.Run("request headers should be dumped in sorted order", func(t *testing.T) {
+
+		keys := []string{"B", "A", "C", "D", "E", "F", "H", "G", "I"}
+		req, _ := http.NewRequest("GET", "/", bytes.NewBuffer(nil))
+		for _, k := range keys {
+			req.Header.Set(k, "")
+		}
+
+		buf, err := DumpRequest(req)
+		require.NoError(t, err)
+		sort.Strings(keys)
+
+		startLine := "GET / HTTP/1.1\n"
+		response :=  startLine + strings.Join(keys, ": \n") + ": \n"
+
+		assert.Contains(t, response, string(Decolorize(buf)))
 	})
 }
 


### PR DESCRIPTION
This fixes issue #47 
