### PR TITLE
Updates |DumpRequest| to iterate over Header keys alphabetically

### DIFF
--- a/dump.go
+++ b/dump.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"regexp"
+	"sort"
 	"strings"
 )
 
@@ -63,11 +64,22 @@ func DumpRequest(req *http.Request) ([]byte, error) {
 		req.ProtoMinor,
 	)
 
-	for key := range req.Header {
+	sortedKeys := sortedHeaderKeys(req)
+	for _, key := range sortedKeys {
 		val := req.Header.Get(key)
 		fmt.Fprintf(buf, "%s: %s\n", withColor(31, key), withColor(32, val))
 	}
 
 	err := writeBody(buf, req)
 	return buf.Bytes(), err
+}
+
+func sortedHeaderKeys(req *http.Request) []string {
+	keys := make([]string, len(req.Header))
+	for header := range req.Header {
+		keys = append(keys, header)
+	}
+
+	sort.Strings(keys)
+	return keys
 }

--- a/dump_test.go
+++ b/dump_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,5 +40,26 @@ func TestDecolorization(t *testing.T) {
 		text := "Some Text"
 		nocolor := Decolorize([]byte(withColor(i, text)))
 		assert.Equal(t, text, string(nocolor))
+	}
+}
+
+func TestAlphabetizedHeaders(t *testing.T) {
+	// TODO: randomize this
+	keys := []string{"Z5", "A1", "M3", "R4", "C2"}
+	sortedKeys := []string{"A1", "C2", "M3", "R4", "Z5"}
+
+	req, _ := http.NewRequest("GET", "/", bytes.NewBuffer(nil))
+	for _, k := range keys {
+		req.Header.Set(k, "")
+	}
+
+	buf, err := DumpRequest(req)
+	require.NoError(t, err)
+	decBuf := Decolorize(buf)
+	priorIdx := -1
+	for _, val := range sortedKeys {
+		foundIdx := strings.Index(string(decBuf), val)
+		assert.True(t, foundIdx > priorIdx)
+		priorIdx = foundIdx
 	}
 }


### PR DESCRIPTION
Adds functionality per issue #47 -- simply added a function to sort the request headers alphabetically and call said function prior to iterating over the request header map in `DumpRequest`