### PR TITLE
simplify `x = x <op> y` to `x <op>= y`

### DIFF
--- a/ui/split.go
+++ b/ui/split.go
@@ -19,7 +19,7 @@ func NewSplit(size int) *Split {
 func (s *Split) Fixed(points ...int) *Split {
 	for _, point := range points {
 		s.points = append(s.points, point+(s.size-s.left))
-		s.left = s.left - point
+		s.left -= point
 	}
 
 	return s
@@ -41,7 +41,7 @@ func (s *Split) Next() int {
 		return 0
 	}
 
-	s.index = s.index + 1
+	s.index++
 	next := s.points[s.index]
 	return next
 }

--- a/ui/ui.go
+++ b/ui/ui.go
@@ -173,7 +173,7 @@ func (ui *UI) AddRequest(g *gocui.Gui, req *http.Request) error {
 	}
 
 	if ui.currentRequest == len(ui.requests)-1 {
-		ui.currentRequest = ui.currentRequest + 1
+		ui.currentRequest++
 	}
 
 	ui.requests = append(ui.requests, buf)
@@ -378,7 +378,8 @@ func (ui *UI) prevRequest(g *gocui.Gui) error {
 		return nil
 	}
 
-	ui.currentRequest = ui.currentRequest - 1
+	ui.currentRequest--
+
 	return ui.updateRequest(g)
 }
 
@@ -390,7 +391,7 @@ func (ui *UI) nextRequest(g *gocui.Gui) error {
 		return nil
 	}
 
-	ui.currentRequest = ui.currentRequest + 1
+	ui.currentRequest++
 	return ui.updateRequest(g)
 }
 


### PR DESCRIPTION
As a special case, simplify `x += 1` to x++ (same for x--).

Found using https://go-critic.github.io/overview#assignOp-ref